### PR TITLE
Fix real estate property add error

### DIFF
--- a/lib/services/property_service.dart
+++ b/lib/services/property_service.dart
@@ -28,6 +28,14 @@ class PropertyService {
       throw Exception('User is not authenticated');
     }
 
+    // نحاول الحصول على معرف مكتب/وكيل العقارات المسجل
+    final userData = await _authService.getUserData();
+    final realEstateId =
+        userData?['real_estate_id'] ?? userData?['id']; // احتياطي في حال اختلف الاسم
+    if (realEstateId == null) {
+      throw Exception('Real estate ID not found');
+    }
+
     final response = await http.post(
       Uri.parse('$_baseUrl/api/properties'),
       headers: {
@@ -36,6 +44,7 @@ class PropertyService {
         'Authorization': 'Bearer $token',
       },
       body: jsonEncode({
+        'real_estate_id': realEstateId,
         'address': address,
         'type': type,
         'price': price,


### PR DESCRIPTION
## Summary
- include the logged-in real estate ID when creating a property so API validation passes

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68840d41a530832989fbe49422661289