### PR TITLE
Remove explicit real estate ID from property creation

### DIFF
--- a/lib/services/property_service.dart
+++ b/lib/services/property_service.dart
@@ -28,13 +28,6 @@ class PropertyService {
       throw Exception('User is not authenticated');
     }
 
-    // نحاول الحصول على معرف مكتب/وكيل العقارات المسجل
-    final userData = await _authService.getUserData();
-    final realEstateId =
-        userData?['real_estate_id'] ?? userData?['id']; // احتياطي في حال اختلف الاسم
-    if (realEstateId == null) {
-      throw Exception('Real estate ID not found');
-    }
 
     final response = await http.post(
       Uri.parse('$_baseUrl/api/properties'),
@@ -44,7 +37,6 @@ class PropertyService {
         'Authorization': 'Bearer $token',
       },
       body: jsonEncode({
-        'real_estate_id': realEstateId,
         'address': address,
         'type': type,
         'price': price,


### PR DESCRIPTION
## Summary
- stop sending `real_estate_id` from `addProperty`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68840ed2e61483298e724528ec830690